### PR TITLE
Fix socket connection path and exec command

### DIFF
--- a/src/hyprland_ipc/dispatch.nim
+++ b/src/hyprland_ipc/dispatch.nim
@@ -393,7 +393,7 @@ proc genString*(cmd: DispatchType, dispatch: bool): string =
   of Custom: 
     result = fmt"{cmd.name}{sep}{cmd.args}"
   of Exec: 
-    result = fmt"exec,{cmd.program}"
+    result = fmt"exec{sep}{cmd.program}"
   of Pass: 
     result = fmt"pass{sep}{cmd.wident}"
   of Global: 

--- a/src/hyprland_ipc/shared.nim
+++ b/src/hyprland_ipc/shared.nim
@@ -30,7 +30,11 @@ proc getSocketPath*(kind: SocketKind): string =
     of kListener:
       ".socket2.sock"
 
-  fmt"/tmp/hypr/{hyprInstanceSig}/{socketName}"
+  when not defined(useOldIpcPath):
+    let runtimeDir = getEnv("XDG_RUNTIME_DIR", "/run/user/1000")
+    result = fmt"{runtimeDir}/hypr/{hyprInstanceSig}/{socketName}"
+  else:
+    result = fmt"/tmp/hypr/{hyprInstanceSig}/{socketName}"
 
 proc writeToSocket*(
   path: string,


### PR DESCRIPTION
I was about to make my first Hyprland IPC script, but Hyprland 0.40.0 has broken this library. The socket path was changed from `/tmp/hypr` to `/run/user/<UID>/hypr/`.

I changed the socket path to the new one and made a compile time switch to use the old directory. Let me know if you want the socket connection code to instead check both directories. The handling of missing $XDG_RUNTIME_DIR could also be improved by reading the user id instead of assuming its 1000 (but it shouldn't be missing on any correctly configured Linux).

I don't have a lot of experience with Hyprland IPC and Hyprland so I'm not sure why the exec command wasn't working with current code. At least with hyprctl `hyprctl dispatch exec firefox` works while `hyprctl dispatch exec,firefox` doesn't. The library seemed to generate the equivalent command string of `hyprctl dispatch exec,firefox`. I changed the format string to use {sep} instead of a comma and that made the command work.